### PR TITLE
Remove cmt when run make clean for examples

### DIFF
--- a/examples/01-info/Makefile
+++ b/examples/01-info/Makefile
@@ -4,5 +4,4 @@ info.byte: info.ml
 	ocamlfind ocamlc -package unix,bitcoin,bitcoin.ocamlnet -linkpkg -o $@ $<
 
 clean:
-	rm -f *.cm[io] *.byte
-
+	rm -f *.cm[iot] *.byte

--- a/examples/02-account/Makefile
+++ b/examples/02-account/Makefile
@@ -4,5 +4,4 @@ account.byte: account.ml
 	ocamlfind ocamlc -package unix,lwt,lwt.ppx,bitcoin,bitcoin.cohttp -linkpkg -o $@ $<
 
 clean:
-	rm -f *.cm[io] *.byte
-
+	rm -f *.cm[iot] *.byte


### PR DESCRIPTION
Personally, I think the cmt files should also be removed when run `make clean`